### PR TITLE
Add env-based CORS origins

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -24,6 +24,7 @@ PRIVATE_KEY_METAMASK=67e2eaa8ea5ed0355dc22cdc1bf477f44d1e1af759dcd84fcc643fc70a7
 JWT_SECRET_KEY=hu&uLODkRLig~OrAwkcg7OLr9gVF,$P7Y;,t'jO;u$dSyyfPlk
 JWT_ACCESS_TOKEN_EXPIRES=3600
 JWT_REFRESH_TOKEN_EXPIRES=86400
+CORS_ORIGINS=http://localhost:3000,http://localhost:3001
 ```
 
 - **Local envs** - works only on local environment when app started directly by python

--- a/backend/application/config.py
+++ b/backend/application/config.py
@@ -17,7 +17,15 @@ class Config:
         'pool_pre_ping': True
     }
     DATABASE_SCHEMA = os.getenv("DATABASE_SCHEMA")
-    CORS_ORIGINS = ["http://localhost:3000", "https://localhost:3000"]
+    origins = os.getenv("CORS_ORIGINS")
+    if origins:
+        CORS_ORIGINS = [origin.strip() for origin in origins.split(",") if origin.strip()]
+    else:
+        CORS_ORIGINS = [
+            "http://localhost:3000",
+            "https://localhost:3000",
+            "http://localhost:3001",
+        ]
 
     # JWT
     JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY")


### PR DESCRIPTION
## Summary
- allow specifying `CORS_ORIGINS` via environment variable
- add `http://localhost:3001` to default allowed origins
- document `CORS_ORIGINS` in backend README

## Testing
- `python3 -m py_compile backend/application/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68553bc3b0288328b57427c6616271dc